### PR TITLE
fix: make ios use new arch components on rn 0.81

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,12 @@
   "codegenConfig": {
     "name": "rnflashlist",
     "type": "components",
-    "jsSrcsDir": "./src/specs"
+    "jsSrcsDir": "./src/specs",
+    "ios": {
+      "componentProvider": {
+        "AutoLayoutView": "AutoLayoutView",
+        "CellContainerView": "CellContainerView"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

Those changes are needed for RN 0.81.x to use new arch components instead of interop.

