### PR TITLE
fix provider spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,12 @@
   "codegenConfig": {
     "name": "rnflashlist",
     "type": "components",
-    "jsSrcsDir": "./src/specs"
+    "jsSrcsDir": "./src/specs",
+    "ios": {
+      "componentProvider": {
+        "AutoLayoutView": "AutoLayoutViewComponentView",
+        "CellContainer": "CellContainerComponentView"
+      }
+    }
   }
 }


### PR DESCRIPTION
Fix with proper component names. prop name is the name passed in JS spec and value is the name of objc class corresponding to the component.